### PR TITLE
Update 06-Photino.VSCodeTemplates.md

### DIFF
--- a/06-Photino.VSCodeTemplates.md
+++ b/06-Photino.VSCodeTemplates.md
@@ -43,10 +43,10 @@ Pack All Project Templates
 6.	Assuming you have *NuGet Package Explorer* installed from the Microsoft Store (or some other package explorer utility), double-click on the NuGet package to inspect, update, and verify it
 7.	You must fill in some of the data manually as `dotnet pack` does not work with the following tags:
 
-| Tag | Value to use |
+ Tag | Value to use 
 | :----- | :-------------- |
 | Owners | TryPhotino |
-| ProjectUrl | https://tryphotino.io |
+| ProjectUrl | http://tryphotino.io |
 | Copyright | TryPhotino 2020 |
 <br>
 


### PR DESCRIPTION
Remove the pipes that enclose the headers.
Use http://tryphotino.io for the link.
Shouldn't the copyright year be 2021?